### PR TITLE
Dashboard improvements

### DIFF
--- a/src/poprox_recommender/components/rankers/openai_ranker.py
+++ b/src/poprox_recommender/components/rankers/openai_ranker.py
@@ -13,6 +13,7 @@ from poprox_concepts import CandidateSet, InterestProfile
 from poprox_concepts.domain import RecommendationList
 from poprox_recommender.components.rankers.ranking_cache import get_ranking_cache_manager
 from poprox_recommender.persistence import get_persistence_manager
+from poprox_recommender.timing_context import get_timeout_risk_info
 
 load_dotenv()
 
@@ -252,6 +253,9 @@ Make sure you select EXACTLY {self.config.num_slots} articles from the candidate
                 try:
                     persistence = get_persistence_manager()
 
+                    # Get timeout risk information
+                    timeout_info = get_timeout_risk_info()
+
                     # Combine all metrics
                     combined_metrics = {
                         "pipeline_type": self.config.pipeline_name,
@@ -263,6 +267,7 @@ Make sure you select EXACTLY {self.config.num_slots} articles from the candidate
                             "ranker": metrics_snapshot,
                         },
                         "issues": [],
+                        "timeout_info": timeout_info,
                     }
 
                     session_id = persistence.save_pipeline_data(

--- a/src/poprox_recommender/components/rewriters/openai_rewriter.py
+++ b/src/poprox_recommender/components/rewriters/openai_rewriter.py
@@ -28,6 +28,7 @@ class LLMRewriterConfig(BaseModel):
 
     model: str = "gpt-4.1-2025-04-14"
     openai_api_key: str = Field(default_factory=lambda: os.getenv("OPENAI_API_KEY"))
+    pipeline_name: str = Field(default="llm_rank_rewrite", description="Name of the pipeline using this rewriter")
 
 
 class LLMRewriter(Component):
@@ -179,7 +180,7 @@ Article text:
 
             # Combine all metrics
             combined_metrics = {
-                "pipeline_type": "llm_rank_rewrite",
+                "pipeline_type": self.config.pipeline_name,
                 "rewriter_model": self.config.model,
                 "llm_metrics": {
                     "ranker": ranker_metrics,

--- a/src/poprox_recommender/components/rewriters/openai_rewriter.py
+++ b/src/poprox_recommender/components/rewriters/openai_rewriter.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field
 
 from poprox_concepts.domain import RecommendationList
 from poprox_recommender.persistence import get_persistence_manager
+from poprox_recommender.timing_context import get_timeout_risk_info
 
 load_dotenv()
 
@@ -178,6 +179,9 @@ Article text:
             if component_snapshot is None:  # pragma: no cover - defensive fallback
                 component_snapshot = component_meta.copy()
 
+            # Get timeout risk information
+            timeout_info = get_timeout_risk_info()
+
             # Combine all metrics
             combined_metrics = {
                 "pipeline_type": self.config.pipeline_name,
@@ -191,6 +195,7 @@ Article text:
                     "rewriter": component_snapshot,
                 },
                 "issues": component_issues,
+                "timeout_info": timeout_info,
             }
 
             session_id = persistence.save_pipeline_data(

--- a/src/poprox_recommender/dashboard/service.py
+++ b/src/poprox_recommender/dashboard/service.py
@@ -22,6 +22,7 @@ class SessionSummary:
     storage_location: Optional[str]
     llm_summary: Optional[Dict[str, Any]]
     pipeline: Optional[str]
+    timeout_info: Optional[Dict[str, Any]]
 
     @property
     def day(self) -> date:
@@ -99,6 +100,7 @@ class PipelineDashboardService:
             storage_location = metadata.get("storage_location")
             llm_summary = metadata.get("llm_summary")
             pipeline = metadata.get("pipeline_type")
+            timeout_info = metadata.get("timeout_info")
 
             summaries.append(
                 SessionSummary(
@@ -111,6 +113,7 @@ class PipelineDashboardService:
                     storage_location=storage_location,
                     llm_summary=llm_summary,
                     pipeline=pipeline,
+                    timeout_info=timeout_info,
                 )
             )
 

--- a/src/poprox_recommender/dashboard/service.py
+++ b/src/poprox_recommender/dashboard/service.py
@@ -21,6 +21,7 @@ class SessionSummary:
     component_summary: Dict[str, Dict[str, Any]]
     storage_location: Optional[str]
     llm_summary: Optional[Dict[str, Any]]
+    pipeline: Optional[str]
 
     @property
     def day(self) -> date:
@@ -97,6 +98,7 @@ class PipelineDashboardService:
             component_summary = metadata.get("component_summary", {})
             storage_location = metadata.get("storage_location")
             llm_summary = metadata.get("llm_summary")
+            pipeline = metadata.get("pipeline_type")
 
             summaries.append(
                 SessionSummary(
@@ -108,6 +110,7 @@ class PipelineDashboardService:
                     component_summary=component_summary,
                     storage_location=storage_location,
                     llm_summary=llm_summary,
+                    pipeline=pipeline,
                 )
             )
 

--- a/src/poprox_recommender/dashboard/templates/index.html
+++ b/src/poprox_recommender/dashboard/templates/index.html
@@ -29,6 +29,8 @@
         <th>Session</th>
         <th>Pipeline</th>
         <th>Articles</th>
+        <th>Duration</th>
+        <th>Timeout Risk</th>
         <th>Ranker</th>
         <th>Rewriter</th>
         <th>Issues</th>
@@ -38,12 +40,26 @@
       {% for session in sessions %}
       {% set ranker = session.component_summary.get('ranker', {}) %}
       {% set rewriter = session.component_summary.get('rewriter', {}) %}
+      {% set timeout_info = session.timeout_info or {} %}
+      {% set elapsed = timeout_info.get('elapsed_seconds') %}
+      {% set is_at_risk = timeout_info.get('is_at_risk', false) %}
+      {% set timeout_pct = timeout_info.get('timeout_risk_percentage', 0) %}
       <tr>
         <td>{{ session.timestamp.strftime("%Y-%m-%d %H:%M:%S") }}</td>
         <td>{{ session.request_id }}</td>
         <td><a href="/sessions/{{ session.session_id }}">{{ session.session_id }}</a></td>
         <td>{{ session.pipeline if session.pipeline else 'n/a' }}</td>
         <td>{{ session.num_articles }}</td>
+        <td>{% if elapsed %}{{ '%.2f'|format(elapsed) }}s{% else %}-{% endif %}</td>
+        <td>
+          {% if is_at_risk %}
+            <span class="timeout-risk">⚠️ {{ '%.0f'|format(timeout_pct) }}%</span>
+          {% elif elapsed %}
+            {{ '%.0f'|format(timeout_pct) }}%
+          {% else %}
+            -
+          {% endif %}
+        </td>
         <td>{{ ranker.get('status', 'n/a') }} {% if ranker.get('duration_seconds') %}<small>({{ '%.2f'|format(ranker['duration_seconds']) }}s)</small>{% endif %}</td>
         <td>{{ rewriter.get('status', 'n/a') }} {% if rewriter.get('duration_seconds') %}<small>({{ '%.2f'|format(rewriter['duration_seconds']) }}s)</small>{% endif %}</td>
         <td>{% if session.issue_count %}<span class="issue-count">{{ session.issue_count }}</span>{% else %}0{% endif %}</td>

--- a/src/poprox_recommender/dashboard/templates/index.html
+++ b/src/poprox_recommender/dashboard/templates/index.html
@@ -3,7 +3,7 @@
 <section class="filters">
   <form method="get" class="filter-form">
     <label>
-      Request ID
+      User ID
       <input type="text" name="request_id" value="{{ selected_request_id }}" placeholder="Exact or prefix" />
     </label>
     <label>
@@ -25,8 +25,9 @@
     <thead>
       <tr>
         <th>Timestamp</th>
-        <th>Request ID</th>
+        <th>User ID</th>
         <th>Session</th>
+        <th>Pipeline</th>
         <th>Articles</th>
         <th>Ranker</th>
         <th>Rewriter</th>
@@ -41,6 +42,7 @@
         <td>{{ session.timestamp.strftime("%Y-%m-%d %H:%M:%S") }}</td>
         <td>{{ session.request_id }}</td>
         <td><a href="/sessions/{{ session.session_id }}">{{ session.session_id }}</a></td>
+        <td>{{ session.pipeline if session.pipeline else 'n/a' }}</td>
         <td>{{ session.num_articles }}</td>
         <td>{{ ranker.get('status', 'n/a') }} {% if ranker.get('duration_seconds') %}<small>({{ '%.2f'|format(ranker['duration_seconds']) }}s)</small>{% endif %}</td>
         <td>{{ rewriter.get('status', 'n/a') }} {% if rewriter.get('duration_seconds') %}<small>({{ '%.2f'|format(rewriter['duration_seconds']) }}s)</small>{% endif %}</td>

--- a/src/poprox_recommender/dashboard/templates/session_detail.html
+++ b/src/poprox_recommender/dashboard/templates/session_detail.html
@@ -3,7 +3,7 @@
 <article class="session-detail">
   <header>
     <h2>Session {{ session.session_id }}</h2>
-    <p class="meta">Request ID: {{ session.request_id }} | Timestamp: {{ session.timestamp.strftime("%Y-%m-%d %H:%M:%S") }}</p>
+    <p class="meta">User ID: {{ session.request_id }} | Timestamp: {{ session.timestamp.strftime("%Y-%m-%d %H:%M:%S") }}</p>
     <p><a href="/">&larr; Back to sessions</a></p>
   </header>
 

--- a/src/poprox_recommender/recommenders/configurations/llm_rank_only.py
+++ b/src/poprox_recommender/recommenders/configurations/llm_rank_only.py
@@ -22,7 +22,7 @@ def configure(builder: PipelineBuilder, num_slots: int, device: str):
     i_profile = builder.create_input("profile", InterestProfile)
 
     # LLM-based ranking only (no rewriting)
-    rank_cfg = LLMRankerConfig(num_slots=num_slots)
+    rank_cfg = LLMRankerConfig(num_slots=num_slots, pipeline_name="llm_rank_only", enable_persistence=True)
     ranker_output = builder.add_component(
         "ranker",
         LLMRanker,

--- a/src/poprox_recommender/recommenders/configurations/llm_rank_rewrite.py
+++ b/src/poprox_recommender/recommenders/configurations/llm_rank_rewrite.py
@@ -27,7 +27,7 @@ def configure(builder: PipelineBuilder, num_slots: int, device: str):
     )
 
     # LLM-based rewriting
-    rewrite_cfg = LLMRewriterConfig()
+    rewrite_cfg = LLMRewriterConfig(pipeline_name="llm_rank_rewrite")
     builder.add_component(
         "recommender",
         LLMRewriter,

--- a/src/poprox_recommender/recommenders/configurations/nrms_baseline_rewrite.py
+++ b/src/poprox_recommender/recommenders/configurations/nrms_baseline_rewrite.py
@@ -184,7 +184,7 @@ def configure(builder: PipelineBuilder, num_slots: int, device: str):
     )
 
     # LLM-based rewriting
-    rewrite_cfg = LLMRewriterConfig()
+    rewrite_cfg = LLMRewriterConfig(pipeline_name="nrms_baseline_rewrite")
     builder.add_component(
         "recommender",
         LLMRewriter,

--- a/src/poprox_recommender/timing_context.py
+++ b/src/poprox_recommender/timing_context.py
@@ -1,0 +1,124 @@
+"""
+Context manager for tracking request timing and detecting potential timeouts.
+
+This module provides utilities to track how long a request has been running
+and detect when we're approaching Lambda timeout limits.
+"""
+
+import os
+import time
+from contextvars import ContextVar
+from typing import Optional
+
+# Context variable to store request start time
+_request_start_time: ContextVar[Optional[float]] = ContextVar("request_start_time", default=None)
+
+# Lambda timeout from environment or default to 30 seconds
+LAMBDA_TIMEOUT_SECONDS = int(os.getenv("AWS_LAMBDA_FUNCTION_TIMEOUT", "30"))
+
+# Buffer before timeout to consider as "at risk" (5 seconds)
+TIMEOUT_RISK_BUFFER_SECONDS = 5
+
+
+def set_request_start_time(start_time: Optional[float] = None) -> None:
+    """
+    Set the start time for the current request.
+
+    Args:
+        start_time: Unix timestamp of when request started. If None, uses current time.
+    """
+    if start_time is None:
+        start_time = time.time()
+    _request_start_time.set(start_time)
+
+
+def get_request_start_time() -> Optional[float]:
+    """
+    Get the start time for the current request.
+
+    Returns:
+        Unix timestamp of when request started, or None if not set.
+    """
+    return _request_start_time.get()
+
+
+def get_elapsed_seconds() -> Optional[float]:
+    """
+    Get the number of seconds elapsed since request started.
+
+    Returns:
+        Seconds elapsed, or None if request start time not set.
+    """
+    start_time = get_request_start_time()
+    if start_time is None:
+        return None
+    return time.time() - start_time
+
+
+def get_remaining_seconds() -> Optional[float]:
+    """
+    Get the number of seconds remaining before Lambda timeout.
+
+    Returns:
+        Seconds remaining, or None if request start time not set.
+    """
+    elapsed = get_elapsed_seconds()
+    if elapsed is None:
+        return None
+    return LAMBDA_TIMEOUT_SECONDS - elapsed
+
+
+def is_approaching_timeout(buffer_seconds: float = TIMEOUT_RISK_BUFFER_SECONDS) -> bool:
+    """
+    Check if we're approaching the Lambda timeout.
+
+    Args:
+        buffer_seconds: Number of seconds before timeout to consider "approaching".
+
+    Returns:
+        True if we're within buffer_seconds of timing out, False otherwise.
+    """
+    remaining = get_remaining_seconds()
+    if remaining is None:
+        return False
+    return remaining <= buffer_seconds
+
+
+def get_timeout_risk_info() -> dict:
+    """
+    Get information about timeout risk for the current request.
+
+    Returns:
+        Dictionary with timeout risk information including:
+        - elapsed_seconds: How long the request has been running
+        - remaining_seconds: How much time is left before timeout
+        - timeout_limit_seconds: The Lambda timeout limit
+        - is_at_risk: Whether we're approaching timeout
+        - timeout_risk_percentage: What percentage of timeout has elapsed (0-100)
+    """
+    elapsed = get_elapsed_seconds()
+    remaining = get_remaining_seconds()
+
+    if elapsed is None or remaining is None:
+        return {
+            "elapsed_seconds": None,
+            "remaining_seconds": None,
+            "timeout_limit_seconds": LAMBDA_TIMEOUT_SECONDS,
+            "is_at_risk": False,
+            "timeout_risk_percentage": 0,
+        }
+
+    percentage = (elapsed / LAMBDA_TIMEOUT_SECONDS) * 100
+
+    return {
+        "elapsed_seconds": elapsed,
+        "remaining_seconds": remaining,
+        "timeout_limit_seconds": LAMBDA_TIMEOUT_SECONDS,
+        "is_at_risk": is_approaching_timeout(),
+        "timeout_risk_percentage": percentage,
+    }
+
+
+def clear_request_context() -> None:
+    """Clear the request timing context."""
+    _request_start_time.set(None)


### PR DESCRIPTION
This pull request introduces request timing and timeout risk tracking throughout the pipeline, adds persistence and reporting of this information, and enhances the dashboard to display timeout risk and pipeline type per session. It also improves configuration clarity for pipeline names and persistence, and updates dashboard labels for better user clarity.

**Request Timing and Timeout Risk Tracking:**

- Added a new module `timing_context.py` that tracks request start time, elapsed time, remaining time before timeout, and whether the request is at risk of timing out. This information is now set at the start of each API request and cleared at the end. (`src/poprox_recommender/timing_context.py`, `src/poprox_recommender/api/main.py`) [[1]](diffhunk://#diff-4ec832b9ef667ae779b899a3db35b0f576dbc103b1389124a8b95d99802bbea2R1-R124) [[2]](diffhunk://#diff-647721a924db8405a46dd4aeb126f6dfa8d2edfaa66ac05972a42e89dbceb04cR4) [[3]](diffhunk://#diff-647721a924db8405a46dd4aeb126f6dfa8d2edfaa66ac05972a42e89dbceb04cR17) [[4]](diffhunk://#diff-647721a924db8405a46dd4aeb126f6dfa8d2edfaa66ac05972a42e89dbceb04cR106-R109) [[5]](diffhunk://#diff-647721a924db8405a46dd4aeb126f6dfa8d2edfaa66ac05972a42e89dbceb04cR170-R172)

**Persistence and Propagation of Timeout Risk Info:**

- The ranker and rewriter components now collect timeout risk information and include it in the metadata when persisting pipeline data. Pipeline configuration now also explicitly sets the pipeline name and persistence flag. (`src/poprox_recommender/components/rankers/openai_ranker.py`, `src/poprox_recommender/components/rewriters/openai_rewriter.py`, `src/poprox_recommender/recommenders/configurations/llm_rank_only.py`, `src/poprox_recommender/recommenders/configurations/llm_rank_rewrite.py`, `src/poprox_recommender/recommenders/configurations/nrms_baseline_rewrite.py`) [[1]](diffhunk://#diff-c18b824cf5afffc164cdaa9223bfc7fc11d49c1a2bc376f8a1efae63e4ef0e55R1) [[2]](diffhunk://#diff-c18b824cf5afffc164cdaa9223bfc7fc11d49c1a2bc376f8a1efae63e4ef0e55R15-R16) [[3]](diffhunk://#diff-c18b824cf5afffc164cdaa9223bfc7fc11d49c1a2bc376f8a1efae63e4ef0e55R39-R40) [[4]](diffhunk://#diff-c18b824cf5afffc164cdaa9223bfc7fc11d49c1a2bc376f8a1efae63e4ef0e55R251-R284) [[5]](diffhunk://#diff-4abb9325baeba50e723a6db371b036e743039e77d5ec21fd3aa92ac9ff4ab575R16) [[6]](diffhunk://#diff-4abb9325baeba50e723a6db371b036e743039e77d5ec21fd3aa92ac9ff4ab575R32) [[7]](diffhunk://#diff-4abb9325baeba50e723a6db371b036e743039e77d5ec21fd3aa92ac9ff4ab575R182-R187) [[8]](diffhunk://#diff-4abb9325baeba50e723a6db371b036e743039e77d5ec21fd3aa92ac9ff4ab575R198) [[9]](diffhunk://#diff-813bd2e81f6e4ba9062dbf2f8e053f9c7b6dc2abad3b4d0b05c1d05952d2a5e8L25-R25) [[10]](diffhunk://#diff-31e25ca0bde3c6e0128fef02fa0fce85924a5208f4b953812d6d023f40836d18L30-R30) [[11]](diffhunk://#diff-ea04b62ffb844059ea34dc5d724ddc6a8bd628d5b0a77e549e07ace322710e26L187-R187)

**Dashboard Enhancements:**

- The dashboard service and templates now display the pipeline type, elapsed duration, and timeout risk percentage for each session. New fields are added to the session summary and shown in both the session list and detail views. (`src/poprox_recommender/dashboard/service.py`, `src/poprox_recommender/dashboard/templates/index.html`, `src/poprox_recommender/dashboard/templates/session_detail.html`) [[1]](diffhunk://#diff-c173c441db4de64afdb96b6bed3895bf09a1a6566f98187e9daaa7d7641c867fR24-R25) [[2]](diffhunk://#diff-c173c441db4de64afdb96b6bed3895bf09a1a6566f98187e9daaa7d7641c867fR102-R103) [[3]](diffhunk://#diff-c173c441db4de64afdb96b6bed3895bf09a1a6566f98187e9daaa7d7641c867fR115-R116) [[4]](diffhunk://#diff-88c5d0518f055f47aa1db3bf23d44aa20678d4e8a8416a5b68901e274a0f0c90L6-R6) [[5]](diffhunk://#diff-88c5d0518f055f47aa1db3bf23d44aa20678d4e8a8416a5b68901e274a0f0c90L28-R33) [[6]](diffhunk://#diff-88c5d0518f055f47aa1db3bf23d44aa20678d4e8a8416a5b68901e274a0f0c90R43-R62) [[7]](diffhunk://#diff-46319949a837a3da8d51010ae2c346a77e977e204abdf45e89060538d0891524L6-R6)

**Configuration and Labeling Improvements:**

- Pipeline configuration now explicitly sets pipeline names and persistence flags for clarity and consistency. Dashboard labels are updated for clarity (e.g., "User ID" instead of "Request ID"). (`src/poprox_recommender/recommenders/configurations/llm_rank_only.py`, `src/poprox_recommender/recommenders/configurations/llm_rank_rewrite.py`, `src/poprox_recommender/recommenders/configurations/nrms_baseline_rewrite.py`, `src/poprox_recommender/dashboard/templates/index.html`, `src/poprox_recommender/dashboard/templates/session_detail.html`) [[1]](diffhunk://#diff-813bd2e81f6e4ba9062dbf2f8e053f9c7b6dc2abad3b4d0b05c1d05952d2a5e8L25-R25) [[2]](diffhunk://#diff-31e25ca0bde3c6e0128fef02fa0fce85924a5208f4b953812d6d023f40836d18L30-R30) [[3]](diffhunk://#diff-ea04b62ffb844059ea34dc5d724ddc6a8bd628d5b0a77e549e07ace322710e26L187-R187) [[4]](diffhunk://#diff-88c5d0518f055f47aa1db3bf23d44aa20678d4e8a8416a5b68901e274a0f0c90L6-R6) [[5]](diffhunk://#diff-46319949a837a3da8d51010ae2c346a77e977e204abdf45e89060538d0891524L6-R6)