### PR TITLE
rewrite caching

### DIFF
--- a/src/poprox_recommender/components/rewriters/openai_rewriter.py
+++ b/src/poprox_recommender/components/rewriters/openai_rewriter.py
@@ -166,10 +166,10 @@ Article text:
 
             if cache_manager and article_id_str:
                 cached_entry = cache_manager.get_cached_rewrite(
-                    request_id=request_id,
                     article_id=article_id_str,
                     user_model_hash=user_model_hash,
                     original_headline=original_headline,
+                    pipeline_name=self.config.pipeline_name,
                 )
                 if cached_entry is not None:
                     art.headline = cached_entry.rewritten_headline
@@ -207,11 +207,11 @@ Article text:
                 metrics["rewritten_headline"] = art.headline
                 if cache_manager and article_id_str:
                     cache_manager.save_rewrite(
-                        request_id=request_id,
                         article_id=article_id_str,
                         user_model_hash=user_model_hash,
                         original_headline=original_headline,
                         rewritten_headline=art.headline,
+                        pipeline_name=self.config.pipeline_name,
                     )
             except Exception as exc:  # pragma: no cover - defensive logging for production observability
                 metrics.update(

--- a/src/poprox_recommender/components/rewriters/openai_rewriter.py
+++ b/src/poprox_recommender/components/rewriters/openai_rewriter.py
@@ -13,6 +13,10 @@ from lenskit.pipeline import Component
 from pydantic import BaseModel, Field
 
 from poprox_concepts.domain import RecommendationList
+from poprox_recommender.components.rewriters.rewrite_cache import (
+    get_rewrite_cache_manager,
+    hash_user_model,
+)
 from poprox_recommender.persistence import get_persistence_manager, is_persistence_enabled, schedule_pipeline_save
 from poprox_recommender.timing_context import get_timeout_risk_info
 
@@ -37,10 +41,15 @@ class LLMRewriterConfig(BaseModel):
     model: str = "gpt-4.1-2025-04-14"
     openai_api_key: str = Field(default_factory=lambda: os.getenv("OPENAI_API_KEY"))
     pipeline_name: str = Field(default="llm_rank_rewrite", description="Name of the pipeline using this rewriter")
+    enable_cache: bool = Field(default=True, description="Enable rewrite caching across pipelines")
 
 
 class LLMRewriter(Component):
     config: LLMRewriterConfig
+
+    def __init__(self, config: LLMRewriterConfig):
+        self.config = config
+        self.cache_manager = get_rewrite_cache_manager() if config.enable_cache else None
 
     def _extract_user_profile_summary(self, user_model: str) -> str:
         """
@@ -120,9 +129,20 @@ class LLMRewriter(Component):
 
         # Extract a concise user profile summary for rewriting
         user_profile_summary = self._extract_user_profile_summary(user_model)
+        user_model_hash = hash_user_model(user_model)
+        cache_manager = self.cache_manager
+        component_meta["cache_enabled"] = cache_manager is not None
+        cache_hits = 0
+        component_meta["cache_hits"] = 0
+        component_meta["cache_misses"] = len(recommendations.articles)
 
         # rewrite article headlines in parallel
         async def rewrite_article(art, client):
+            nonlocal cache_hits
+            original_headline = art.headline
+            article_id = getattr(art, "article_id", None)
+            article_id_str = str(article_id) if article_id is not None else ""
+
             # build prompt using the concise user profile summary
             input_txt = f"""User interest profile:
 {user_profile_summary}
@@ -141,6 +161,30 @@ Article text:
                 "start_time": datetime.now(timezone.utc).isoformat(),
             }
             call_start = time.perf_counter()
+
+            metrics["cache_hit"] = False
+
+            if cache_manager and article_id_str:
+                cached_entry = cache_manager.get_cached_rewrite(
+                    request_id=request_id,
+                    article_id=article_id_str,
+                    user_model_hash=user_model_hash,
+                    original_headline=original_headline,
+                )
+                if cached_entry is not None:
+                    art.headline = cached_entry.rewritten_headline
+                    metrics.update(
+                        {
+                            "status": "cached",
+                            "duration_seconds": 0.0,
+                            "cache_hit": True,
+                            "rewritten_headline": art.headline,
+                        }
+                    )
+                    metrics["end_time"] = datetime.now(timezone.utc).isoformat()
+                    rewriter_metrics.append(metrics)
+                    cache_hits += 1
+                    return
 
             try:
                 response = await client.responses.parse(
@@ -161,6 +205,14 @@ Article text:
                 # Update the article headline with the rewritten one
                 art.headline = response.output_parsed.headline
                 metrics["rewritten_headline"] = art.headline
+                if cache_manager and article_id_str:
+                    cache_manager.save_rewrite(
+                        request_id=request_id,
+                        article_id=article_id_str,
+                        user_model_hash=user_model_hash,
+                        original_headline=original_headline,
+                        rewritten_headline=art.headline,
+                    )
             except Exception as exc:  # pragma: no cover - defensive logging for production observability
                 metrics.update(
                     {
@@ -192,6 +244,8 @@ Article text:
             async with openai.AsyncOpenAI(api_key=self.config.openai_api_key) as client:
                 tasks = [rewrite_article(art, client) for art in recommendations.articles]
                 await asyncio.gather(*tasks)
+            component_meta["cache_hits"] = cache_hits
+            component_meta["cache_misses"] = max(len(recommendations.articles) - cache_hits, 0)
 
         try:
             asyncio.run(rewrite_all())

--- a/src/poprox_recommender/components/rewriters/rewrite_cache.py
+++ b/src/poprox_recommender/components/rewriters/rewrite_cache.py
@@ -1,0 +1,145 @@
+import hashlib
+import os
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class RewriteCacheEntry:
+    """
+    Cached rewrite result for a single article within a request context.
+    """
+
+    rewritten_headline: str
+    original_headline: str
+    user_model_hash: str
+    article_id: str
+    cached_at: float
+
+
+def _generate_cache_key(request_id: str, article_id: str, user_model_hash: str) -> str:
+    return f"{request_id}:{article_id}:{user_model_hash}"
+
+
+def hash_user_model(user_model: str | None) -> str:
+    """
+    Generate a stable hash for the user model string. Falls back to hashing an empty string.
+    """
+    if not user_model:
+        return "0" * 16
+    return hashlib.sha256(user_model.encode("utf-8")).hexdigest()[:16]
+
+
+class MemoryRewriteCache:
+    """
+    Simple in-memory LRU cache for rewrite results shared within a Lambda container.
+    """
+
+    def __init__(self, max_entries: int = 512, ttl_seconds: int = 900):
+        self.max_entries = max(1, max_entries)
+        self.ttl_seconds = max(0, ttl_seconds)
+        self._store: "OrderedDict[str, RewriteCacheEntry]" = OrderedDict()
+        self._lock = threading.Lock()
+
+    def _is_expired(self, entry: RewriteCacheEntry) -> bool:
+        if self.ttl_seconds == 0:
+            return False
+        return time.time() - entry.cached_at > self.ttl_seconds
+
+    def get_cached_rewrite(
+        self,
+        request_id: str,
+        article_id: str,
+        user_model_hash: str,
+        original_headline: str,
+    ) -> Optional[RewriteCacheEntry]:
+        cache_key = _generate_cache_key(request_id, article_id, user_model_hash)
+        with self._lock:
+            entry = self._store.get(cache_key)
+            if entry is None:
+                return None
+
+            if self._is_expired(entry) or entry.original_headline != original_headline:
+                self._store.pop(cache_key, None)
+                return None
+
+            self._store.move_to_end(cache_key)
+            return entry
+
+    def save_rewrite(
+        self,
+        request_id: str,
+        article_id: str,
+        user_model_hash: str,
+        original_headline: str,
+        rewritten_headline: str,
+    ) -> str:
+        cache_key = _generate_cache_key(request_id, article_id, user_model_hash)
+        entry = RewriteCacheEntry(
+            rewritten_headline=rewritten_headline,
+            original_headline=original_headline,
+            user_model_hash=user_model_hash,
+            article_id=article_id,
+            cached_at=time.time(),
+        )
+        with self._lock:
+            self._store[cache_key] = entry
+            self._store.move_to_end(cache_key)
+            while len(self._store) > self.max_entries:
+                self._store.popitem(last=False)
+        return cache_key
+
+    def clear(self):
+        with self._lock:
+            self._store.clear()
+
+
+_memory_cache: Optional[MemoryRewriteCache] = None
+
+
+def _get_memory_cache() -> MemoryRewriteCache:
+    global _memory_cache
+    if _memory_cache is None:
+        size = int(os.getenv("REWRITE_CACHE_MEMORY_SIZE", "512"))
+        ttl = int(os.getenv("REWRITE_CACHE_TTL_SECONDS", "900"))
+        _memory_cache = MemoryRewriteCache(max_entries=max(1, size), ttl_seconds=max(0, ttl))
+    return _memory_cache
+
+
+def _determine_cache_mode() -> str:
+    mode = os.getenv("REWRITE_CACHE_MODE")
+    if mode:
+        return mode.strip().lower()
+
+    enabled = os.getenv("REWRITE_CACHE_ENABLED")
+    if enabled is None:
+        return "memory"
+
+    value = enabled.strip().lower()
+    if value in {"0", "false", "no", "off"}:
+        return "off"
+    return "memory"
+
+
+def get_rewrite_cache_manager() -> Optional[MemoryRewriteCache]:
+    """
+    Get a rewrite cache instance based on environment configuration.
+    """
+    mode = _determine_cache_mode()
+    if mode in {"off", "none"}:
+        return None
+
+    # Only memory mode is supported today; fall back to memory for unknown modes.
+    return _get_memory_cache()
+
+
+def reset_rewrite_cache():
+    """
+    Reset in-memory cache for testing.
+    """
+    cache = get_rewrite_cache_manager()
+    if cache is not None:
+        cache.clear()

--- a/tests/test_rewrite_cache.py
+++ b/tests/test_rewrite_cache.py
@@ -1,0 +1,132 @@
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from poprox_recommender.components.rewriters.openai_rewriter import LLMRewriter, LLMRewriterConfig
+from poprox_recommender.components.rewriters.rewrite_cache import (
+    MemoryRewriteCache,
+    get_rewrite_cache_manager,
+    hash_user_model,
+    reset_rewrite_cache,
+)
+
+poprox_concepts = pytest.importorskip("poprox_concepts")
+from poprox_concepts import Article  # noqa: E402
+from poprox_concepts.domain import RecommendationList  # noqa: E402
+
+
+def test_memory_rewrite_cache_roundtrip():
+    cache = MemoryRewriteCache(max_entries=4, ttl_seconds=60)
+    request_id = "req-1"
+    article_id = "article-123"
+    user_hash = hash_user_model("sample user model")
+
+    cache.save_rewrite(
+        request_id=request_id,
+        article_id=article_id,
+        user_model_hash=user_hash,
+        original_headline="Original Headline",
+        rewritten_headline="Rewritten Headline",
+    )
+
+    entry = cache.get_cached_rewrite(
+        request_id=request_id,
+        article_id=article_id,
+        user_model_hash=user_hash,
+        original_headline="Original Headline",
+    )
+    assert entry is not None
+    assert entry.rewritten_headline == "Rewritten Headline"
+
+
+def test_memory_rewrite_cache_headline_mismatch_invalidates():
+    cache = MemoryRewriteCache(max_entries=4, ttl_seconds=60)
+    request_id = "req-2"
+    article_id = "article-456"
+    user_hash = hash_user_model("user model")
+
+    cache.save_rewrite(
+        request_id=request_id,
+        article_id=article_id,
+        user_model_hash=user_hash,
+        original_headline="Correct Headline",
+        rewritten_headline="Rewritten",
+    )
+
+    entry = cache.get_cached_rewrite(
+        request_id=request_id,
+        article_id=article_id,
+        user_model_hash=user_hash,
+        original_headline="Different Headline",
+    )
+    assert entry is None
+
+
+def test_get_rewrite_cache_manager_disabled():
+    with patch.dict(os.environ, {"REWRITE_CACHE_ENABLED": "false"}):
+        cache = get_rewrite_cache_manager()
+        assert cache is None
+
+
+@patch("poprox_recommender.components.rewriters.openai_rewriter.is_persistence_enabled", return_value=False)
+def test_llm_rewriter_uses_cached_rewrites(_mock_persistence):
+    reset_rewrite_cache()
+
+    user_model = """Topics the user has shown interest in (from most to least):
+Topic One, Topic Two
+
+Topics the user has clicked on (from most to least):
+Topic One, Topic Three
+
+Headlines of articles the user has clicked on recently:
+Sample headline
+"""
+
+    article_id = uuid4()
+    request_id = "request-xyz"
+
+    def make_ranker_output():
+        article = Article(
+            article_id=article_id,
+            headline="Original headline",
+            body="Body text for the article.",
+        )
+        recommendations = RecommendationList(articles=[article])
+        return (recommendations, user_model, request_id, {}, {})
+
+    class DummyAsyncClient:
+        def __init__(self, parse_mock):
+            self.responses = SimpleNamespace(parse=parse_mock)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    parse_mock = AsyncMock()
+    parse_mock.return_value = SimpleNamespace(
+        usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        output_parsed=SimpleNamespace(headline="Rewritten headline"),
+    )
+
+    def async_openai_factory(*args, **kwargs):
+        return DummyAsyncClient(parse_mock)
+
+    with patch("poprox_recommender.components.rewriters.openai_rewriter.openai.AsyncOpenAI", side_effect=async_openai_factory):
+        rewriter = LLMRewriter(LLMRewriterConfig(enable_cache=True))
+
+        first_output = make_ranker_output()
+        first_result = rewriter(first_output)
+        assert parse_mock.await_count == 1
+        assert first_result.articles[0].headline == "Rewritten headline"
+
+        second_output = make_ranker_output()
+        second_result = rewriter(second_output)
+
+        # Ensure we reused cached rewrite and did not make another LLM call
+        assert parse_mock.await_count == 1
+        assert second_result.articles[0].headline == "Rewritten headline"

--- a/tests/test_rewrite_cache.py
+++ b/tests/test_rewrite_cache.py
@@ -20,23 +20,22 @@ from poprox_concepts.domain import RecommendationList  # noqa: E402
 
 def test_memory_rewrite_cache_roundtrip():
     cache = MemoryRewriteCache(max_entries=4, ttl_seconds=60)
-    request_id = "req-1"
     article_id = "article-123"
     user_hash = hash_user_model("sample user model")
 
     cache.save_rewrite(
-        request_id=request_id,
         article_id=article_id,
         user_model_hash=user_hash,
         original_headline="Original Headline",
         rewritten_headline="Rewritten Headline",
+        pipeline_name="test-pipeline",
     )
 
     entry = cache.get_cached_rewrite(
-        request_id=request_id,
         article_id=article_id,
         user_model_hash=user_hash,
         original_headline="Original Headline",
+        pipeline_name="test-pipeline",
     )
     assert entry is not None
     assert entry.rewritten_headline == "Rewritten Headline"
@@ -44,23 +43,22 @@ def test_memory_rewrite_cache_roundtrip():
 
 def test_memory_rewrite_cache_headline_mismatch_invalidates():
     cache = MemoryRewriteCache(max_entries=4, ttl_seconds=60)
-    request_id = "req-2"
     article_id = "article-456"
     user_hash = hash_user_model("user model")
 
     cache.save_rewrite(
-        request_id=request_id,
         article_id=article_id,
         user_model_hash=user_hash,
         original_headline="Correct Headline",
         rewritten_headline="Rewritten",
+        pipeline_name="test-pipeline",
     )
 
     entry = cache.get_cached_rewrite(
-        request_id=request_id,
         article_id=article_id,
         user_model_hash=user_hash,
         original_headline="Different Headline",
+        pipeline_name="test-pipeline",
     )
     assert entry is None
 


### PR DESCRIPTION
This pull request introduces a headline rewrite caching mechanism for the LLM-based rewriter component, aiming to reduce redundant LLM calls and improve efficiency. The main changes include adding an in-memory LRU cache, integrating cache lookups and updates into the headline rewriting flow, and providing configuration and tests for the new caching logic.

**Rewrite Caching Implementation:**

* Added a new module `rewrite_cache.py` with a `MemoryRewriteCache` class to provide an in-memory, thread-safe LRU cache for rewritten headlines, including cache entry structure, cache key generation, and cache expiration logic.
* Implemented cache lookup and update in `LLMRewriter`: before rewriting a headline, the cache is checked, and if a cached rewrite exists, it is used; otherwise, the result is saved to cache after a successful rewrite. [[1]](diffhunk://#diff-4abb9325baeba50e723a6db371b036e743039e77d5ec21fd3aa92ac9ff4ab575R16-R19) [[2]](diffhunk://#diff-4abb9325baeba50e723a6db371b036e743039e77d5ec21fd3aa92ac9ff4ab575R132-R145) [[3]](diffhunk://#diff-4abb9325baeba50e723a6db371b036e743039e77d5ec21fd3aa92ac9ff4ab575R165-R188) [[4]](diffhunk://#diff-4abb9325baeba50e723a6db371b036e743039e77d5ec21fd3aa92ac9ff4ab575R208-R215)

**Configuration and Metrics:**

* Added an `enable_cache` flag to `LLMRewriterConfig` to allow enabling/disabling caching via configuration, and updated component metadata to track cache hits and misses for observability. [[1]](diffhunk://#diff-4abb9325baeba50e723a6db371b036e743039e77d5ec21fd3aa92ac9ff4ab575R44-R53) [[2]](diffhunk://#diff-4abb9325baeba50e723a6db371b036e743039e77d5ec21fd3aa92ac9ff4ab575R247-R248)

**Testing and Validation:**

* Added comprehensive tests in `test_rewrite_cache.py` to verify cache roundtrip, cache invalidation on headline mismatch, cache enable/disable behavior, and correct cache usage in the LLM rewriter.

**Utility Functions:**

* Provided utility functions for stable user model hashing and cache manager retrieval, supporting environment-based configuration.